### PR TITLE
Add tagType check when checking programmable

### DIFF
--- a/solana/programs/cupcake/src/instructions/bake_sprinkle/mod.rs
+++ b/solana/programs/cupcake/src/instructions/bake_sprinkle/mod.rs
@@ -167,7 +167,7 @@ pub fn handler<'a, 'b, 'c, 'info>(
           let token_account: Account<TokenAccount> = Account::try_from(token)?;
           
           let mut is_programmable = false;
-          if ctx.remaining_accounts.len() > 2 {
+          if ctx.remaining_accounts.len() > 2 && tag_type != TagType::HotPotato {
               let token_metadata = Metadata::from_account_info(&ctx.remaining_accounts[2])?;
               is_programmable = token_metadata.programmable_config != None;
           }


### PR DESCRIPTION
check if a sprinkle is hotPotato when baking, because we can't rely on the number of remaining accounts being 2